### PR TITLE
Git-ignore stack lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist/
 bin/
 .stack-work/
+stack*.yaml.lock


### PR DESCRIPTION
These populate the root git directory when building using the commands
recommended in the README file.