### PR TITLE
Place <file>:<line>:<col> first in an error message

### DIFF
--- a/src/Language/SystemVerilog/Parser/Lex.x
+++ b/src/Language/SystemVerilog/Parser/Lex.x
@@ -541,7 +541,7 @@ lexicalError :: String -> Alex a
 lexicalError msg = do
     (pn, _, _, _) <- alexGetInput
     pos <- toTokPos pn
-    alexError $ "Lexical error: " ++ msg ++ ", at " ++ show pos
+    alexError $ show pos ++ ": Lexical error: " ++ msg
 
 -- get the current user state
 get :: Alex AlexUserState

--- a/src/Language/SystemVerilog/Parser/Parse.y
+++ b/src/Language/SystemVerilog/Parser/Parse.y
@@ -1207,7 +1207,7 @@ DimFn :: { DimFn }
 parseError :: [Token] -> ExceptT String IO a
 parseError a = case a of
   []              -> throwError $ "Parse error: no tokens left to parse."
-  Token t s p : _ -> throwError $ "Parse error: unexpected token '" ++ s ++ "' (" ++ show t ++ ") at " ++ show p ++ "."
+  Token t s p : _ -> throwError $ show p ++ ": Parse error: unexpected token '" ++ s ++ "' (" ++ show t ++ ")."
 
 genItemsToGenItem :: [GenItem] -> GenItem
 genItemsToGenItem [x] = x


### PR DESCRIPTION
This is the same as most compilers (e.g. gcc and clang) but also
verilog tools (e.g. yosys) output error mesasge in a standardized form.

This form can immediately be parsed by IDE tools that can jumping
through a list of error messages, placing the cursor at the given
file position.

This change simply re-arranges the error message printing to conform to that
standard.

Signed-off-by: Henner Zeller <h.zeller@acm.org>