### PR TITLE
An example for distributing prebuilt binaries

### DIFF
--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install dependencies
       run: |
-        stack upgarade
+        stack upgrade
     - name: Build
       run: |
         make

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -1,21 +1,85 @@
-name: Haskell CI
+name: Build Release Binary
 
-on: [push]
+on:
+  push:
+    tags:
+      - v*
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
       run: |
-        stack upgrade
-    - name: Build
+        brew install haskell-stack shunit2 icarus-verilog || ls
+        sudo apt-get install -y haskell-stack shunit2 flex bison autoconf gperf || ls
+    - name: Cache iverilog
+      uses: actions/cache@v1
+      with:
+        path: ~/.local
+        key: ${{ runner.OS }}-iverilog-10-2
+        restore-keys: ${{ runner.OS }}-iverilog-10-2
+    - name: Install iverilog
       run: |
-        make
-        zip --junk-paths sv2v ./bin/sv2v
+        if [ "${{ runner.OS }}" = "Linux" ]; then
+          if [ ! -e "$HOME/.local/bin/iverilog" ]; then
+            curl --retry-max-time 60 -L https://github.com/steveicarus/iverilog/archive/v10_2.tar.gz > iverilog.tar.gz
+            tar -xzf iverilog.tar.gz
+            cd iverilog-10_2
+            autoconf
+            ./configure --prefix=$HOME/.local
+            make
+            make install
+            cd ..
+          fi
+        fi
+    - name: Cache Build
+      uses: actions/cache@v1
+      with:
+        path: ~/.stack
+        key: ${{ runner.OS }}-${{ hashFiles('**/stack.yaml') }}-${{ hashFiles('**/sv2v.cabal') }}
+        restore-keys: |
+          ${{ runner.OS }}-${{ hashFiles('**/stack.yaml') }}-${{ hashFiles('**/sv2v.cabal') }}
+          ${{ runner.OS }}-${{ hashFiles('**/stack.yaml') }}-
+          ${{ runner.OS }}-
+    - name: Build
+      run: make
+#     - name: Test
+#       run: make test
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: matrix.os
+        path: bin
+      
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    
+    steps:
+    - run: sudo apt-get install -y tree
+    - name: Download Linux artifact
+    - uses: actions/download-artifact@v1
+      with:
+        name: ubuntu-latest
+        path: ubuntu-latest
+    - name: Download MacOS artifact
+    - uses: actions/download-artifact@v1
+      with:
+        name: macos-latest
+        path: macos-latest
+    - name: Testing
+      run: |
+        tree
+    - name: Zip binary
+      run: |
+        zip --junk-paths linux ./ubuntu-latest/sv2v
+        zip --junk-paths macos ./macos-latest/sv2v
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1.0.0
@@ -26,13 +90,21 @@ jobs:
         release_name: Release ${{ github.ref }}
         draft: false
         prerelease: true
-    - name: Upload Release Asset
-      id: upload-release-asset 
+    - name: Upload Linux Release Asset
       uses: actions/upload-release-asset@v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: ./sv2v.zip
-        asset_name: sv2v.zip
+        asset_path: ./linux.zip
+        asset_name: linux.zip
+        asset_content_type: application/zip
+    - name: Upload MacOS Release Asset
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: ./macos.zip
+        asset_name: macos.zip
         asset_content_type: application/zip

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -51,6 +51,8 @@ jobs:
       run: make
     - name: Test
       run: make test
+    - name: Packaging for artifact
+      run: cp LICENSE NOTICE README.md bin
     - name: Upload artifact
       uses: actions/upload-artifact@v1
       with:
@@ -67,16 +69,16 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: Linux
-        path: Linux
+        path: sv2v-Linux
     - name: Download MacOS artifact
       uses: actions/download-artifact@v1
       with:
         name: macOS
-        path: macOS
+        path: sv2v-macOS
     - name: Zip binary
       run: |
-        zip --junk-paths Linux ./Linux/sv2v
-        zip --junk-paths macOS ./macOS/sv2v
+        zip sv2v-Linux ./sv2v-Linux/sv2v ./sv2v-Linux/LICENSE ./sv2v-Linux/NOTICE ./sv2v-Linux/README.md
+        zip sv2v-macOS ./sv2v-macOS/sv2v ./sv2v-macOS/LICENSE ./sv2v-macOS/NOTICE ./sv2v-macOS/README.md
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1.0.0
@@ -93,8 +95,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: ./Linux.zip
-        asset_name: Linux.zip
+        asset_path: ./sv2v-Linux.zip
+        asset_name: sv2v-Linux.zip
         asset_content_type: application/zip
     - name: Upload MacOS Release Asset
       uses: actions/upload-release-asset@v1.0.1
@@ -102,6 +104,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: ./macOS.zip
-        asset_name: macOS.zip
+        asset_path: ./sv2v-macOS.zip
+        asset_name: sv2v-macOS.zip
         asset_content_type: application/zip

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -49,8 +49,8 @@ jobs:
           ${{ runner.OS }}-
     - name: Build
       run: make
-#     - name: Test
-#       run: make test
+    - name: Test
+      run: make test
     - name: Upload artifact
       uses: actions/upload-artifact@v1
       with:
@@ -73,9 +73,6 @@ jobs:
       with:
         name: macos-latest
         path: macos-latest
-    - name: Testing
-      run: |
-        tree
     - name: Zip binary
       run: |
         zip --junk-paths linux ./ubuntu-latest/sv2v

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v1
       with:
-        name: matrix.os
+        name: ${{ matrix.os }}
         path: bin
       
   release:

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -1,0 +1,38 @@
+name: Haskell CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: |
+        curl -sSL https://get.haskellstack.org/ | sh
+    - name: Build
+      run: |
+        make
+        zip --junk-paths sv2v ./bin/sv2v
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: ./sv2v.zip
+        asset_name: sv2v.zip
+        asset_content_type: application/zip

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -2,8 +2,8 @@ name: Build Release Binary
 
 on:
   push:
-#     tags:
-#       - v*
+    tags:
+      - v*
 
 jobs:
   build:

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -64,12 +64,12 @@ jobs:
     steps:
     - run: sudo apt-get install -y tree
     - name: Download Linux artifact
-    - uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v1
       with:
         name: ubuntu-latest
         path: ubuntu-latest
     - name: Download MacOS artifact
-    - uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v1
       with:
         name: macos-latest
         path: macos-latest

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -2,8 +2,8 @@ name: Build Release Binary
 
 on:
   push:
-    tags:
-      - v*
+#     tags:
+#       - v*
 
 jobs:
   build:

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v1
       with:
-        name: ${{ matrix.os }}
+        name: ${{ runner.os }}
         path: bin
       
   release:
@@ -66,17 +66,17 @@ jobs:
     - name: Download Linux artifact
       uses: actions/download-artifact@v1
       with:
-        name: ubuntu-latest
-        path: ubuntu-latest
+        name: Linux
+        path: Linux
     - name: Download MacOS artifact
       uses: actions/download-artifact@v1
       with:
-        name: macos-latest
-        path: macos-latest
+        name: macOS
+        path: macOS
     - name: Zip binary
       run: |
-        zip --junk-paths linux ./ubuntu-latest/sv2v
-        zip --junk-paths macos ./macos-latest/sv2v
+        zip --junk-paths Linux ./Linux/sv2v
+        zip --junk-paths macOS ./macOS/sv2v
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1.0.0
@@ -93,8 +93,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: ./linux.zip
-        asset_name: linux.zip
+        asset_path: ./Linux.zip
+        asset_name: Linux.zip
         asset_content_type: application/zip
     - name: Upload MacOS Release Asset
       uses: actions/upload-release-asset@v1.0.1
@@ -102,6 +102,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: ./macos.zip
-        asset_name: macos.zip
+        asset_path: ./macOS.zip
+        asset_name: macOS.zip
         asset_content_type: application/zip

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install dependencies
       run: |
-        curl -sSL https://get.haskellstack.org/ | sh
+        stack upgarade
     - name: Build
       run: |
         make


### PR DESCRIPTION
I wouldn't merge this as is, but here's an example of using GitHub Actions CI to build `sv2v` binaries for Linux. You can see the end results on my fork here: https://github.com/hofstee/sv2v/releases

The binaries at least seem to work on my laptop, I'm not too familiar with Haskell and if it statically links things while building its binaries.