### PR TITLE
add .gitattributes for GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.hs  linguist-language=Haskell
+*.sh  linguist-language=Shell
+*.sv  linguist-language=SystemVerilog
+*.svh linguist-language=SystemVerilog
+*.v   linguist-language=Verilog
+*.vh  linguist-language=Verilog

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,1 @@
-*.hs  linguist-language=Haskell
-*.sh  linguist-language=Shell
-*.sv  linguist-language=SystemVerilog
-*.svh linguist-language=SystemVerilog
-*.v   linguist-language=Verilog
-*.vh  linguist-language=Verilog
+*.v linguist-language=Verilog


### PR DESCRIPTION
Some .v files are incorrectly identified by GitHub Linguist as Coq or Vlang files, which confuses people who browse the repo on GitHub. According to [this](https://github.com/github/linguist#using-gitattributes), adding a .gitattributes file can solve this problem.