### PR TITLE
src/sv2v.hs: Remove duplicate source files

### DIFF
--- a/src/sv2v.hs
+++ b/src/sv2v.hs
@@ -9,7 +9,7 @@ import System.IO (hPrint, hPutStrLn, stderr, stdout)
 import System.Exit (exitFailure, exitSuccess)
 
 import Control.Monad (filterM, when, zipWithM_)
-import Data.List (elemIndex, intercalate)
+import Data.List (elemIndex, intercalate, nub)
 
 import Convert (convert)
 import Job (readJob, Job(..), Write(..))
@@ -80,7 +80,7 @@ main = do
     -- parse the input files
     let defines = map splitDefine $ define job
     result <- parseFiles (incdir job) defines (siloed job)
-        (skipPreprocessor job) (files job)
+        (skipPreprocessor job) (nub $ files job)
     case result of
         Left msg -> do
             hPutStrLn stderr msg


### PR DESCRIPTION
In many projects, the dependency tool usage does not ensure to provide only one single instance of each input file. An example which produces multiple times the same source file is here: https://github.com/openhwgroup/cva6/blob/6000e32b4181304901adc4c8d72870ebc94473a5/Makefile#L147.

This straightforward PR removes duplicate input source files. It makes sv2v more compatible with existing build systems.