### PR TITLE
Add option to send output directly to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ running `stack install`, or copy over the executable manually.
 
 sv2v takes in a list of files and prints the converted Verilog to `stdout`.
 Using `--write=adjacent` will create a converted `.v` for every `.sv` input file
-rather than printing to `stdout`.
+rather than printing to `stdout`. `--write`/`-w` can also be used to specify a
+path to a `.v` output file.
 
 Users may specify `include` search paths, define macros during preprocessing,
 and exclude some of the conversions. Specifying `-` as an input file will read
@@ -95,8 +96,9 @@ Conversion:
   -E --exclude=CONV         Exclude a particular conversion (always, assert,
                             interface, or logic)
   -v --verbose              Retain certain conversion artifacts
-  -w --write=MODE           How to write output; default is 'stdout'; use
-                            'adjacent' to create a .v file next to each input
+  -w --write=MODE/FILE      How to write output; default is 'stdout'; use
+                            'adjacent' to create a .v file next to each input;
+                            use a path ending in .v to write to a file
 Other:
      --help                 Display help message
      --version              Print version information

--- a/src/Job.hs
+++ b/src/Job.hs
@@ -26,6 +26,7 @@ data Exclude
 data Write
     = Stdout
     | Adjacent
+    | File
     deriving (Show, Typeable, Data, Eq)
 
 instance Default Write where
@@ -66,7 +67,8 @@ defaultJob = Job
     , verbose = nam "verbose" &= help "Retain certain conversion artifacts"
     , write = nam_ "write" &= name "w" &= typ "MODE"
         &= help ("How to write output; default is 'stdout'; use 'adjacent' to"
-            ++ " create a .v file next to each input")
+            ++ " create a .v file next to each input; use 'file' to create a"
+            ++ " sv2v_output.v file")
     }
     &= program "sv2v"
     &= summary ("sv2v " ++ version)

--- a/src/sv2v.hs
+++ b/src/sv2v.hs
@@ -64,9 +64,8 @@ writeOutput _ [] [] =
     hPutStrLn stderr "Warning: No input files specified (try `sv2v --help`)"
 writeOutput Stdout _ asts =
     hPrint stdout $ concat asts
-writeOutput File _ asts =
+writeOutput (File f) _ asts =
     writeFile f $ show $ concat asts
-    where f = "sv2v_output.v"
 writeOutput Adjacent inPaths asts = do
     outPaths <- mapM rewritePath inPaths
     badPaths <- filterM doesFileExist outPaths

--- a/src/sv2v.hs
+++ b/src/sv2v.hs
@@ -64,6 +64,9 @@ writeOutput _ [] [] =
     hPutStrLn stderr "Warning: No input files specified (try `sv2v --help`)"
 writeOutput Stdout _ asts =
     hPrint stdout $ concat asts
+writeOutput File _ asts =
+    writeFile f $ show $ concat asts
+    where f = "sv2v_output.v"
 writeOutput Adjacent inPaths asts = do
     outPaths <- mapM rewritePath inPaths
     badPaths <- filterM doesFileExist outPaths

--- a/test/write/run.sh
+++ b/test/write/run.sh
@@ -66,6 +66,30 @@ test_adjacent_extension() {
         "$stderr"
 }
 
+test_file() {
+    runAndCapture --write=stdout *.sv
+    expected="$stdout"
+
+    rm -f out.v
+    runAndCapture --write=out.v *.sv
+    assertTrue "file conversion should succeed" $result
+    assertNull "stdout should be empty" "$stdout"
+    assertNull "stderr should be empty" "$stderr"
+
+    actual=`cat out.v`
+    assertEquals "file output should match combined" "$expected" "$actual"
+    clearArtifacts
+}
+
+test_unknown() {
+    runAndCapture --write=unknown *.sv
+    assertFalse "unknown write mode should fail" $result
+    assertNull "stdout should be empty" "$stdout"
+    assertEquals "stderr should list valid write modes" \
+        "invalid --write \"unknown\", expected stdout, adjacent, or a path ending in .v" \
+        "$stderr"
+}
+
 source ../lib/functions.sh
 
 . shunit2


### PR DESCRIPTION
This PR adds support for using `--write=file` which will write the output directly to a `sv2v_output.v` file. This is useful for integrating sv2v with tools that expect a flattened verilog file where redirecting stdout is inconvenient because it is set up to be used for logging, and all the other tools in the flow communicate via files.

Another solution would be to allow the user to directly specify the filename of the output (instead of hardcoding `sv2v_output.v`), but this is a bit more complicated and isn't very different from the hardcoded filename.

Thanks for the great tool!