### PR TITLE
Fixing a bug where always_* are not converted when attributed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   static prefixes, which could cause deep recursion and run out of memory on
   some designs
 * Fixed overzealous removal of explicitly unconnected ports (e.g., `.a()`)
+* Fixed an issue that left `always_comb`, `always_latch`, and `always_ff`
+  unconverted when tagged with an attribute
 * Fixed unneeded scoping of constant function calls used in type lookups
 * `/*/` is no longer interpreted as a self-closing block comment, e.g.,
   `$display("a"/*/,"b"/* */);` previously printed "ab", but now prints "a"

--- a/src/Convert/AlwaysKW.hs
+++ b/src/Convert/AlwaysKW.hs
@@ -198,6 +198,8 @@ traverseModuleItem item@(MIPackageItem (Function _ _ x decls _)) = do
 traverseModuleItem item@(MIPackageItem (Task _ x decls _)) = do
     insertElem x $ Proc [] (ports decls)
     return item
+traverseModuleItem (MIAttr attr item) =
+    MIAttr attr <$> traverseModuleItem item
 traverseModuleItem other = return other
 
 toEvent :: (Bool, [Expr]) -> Event

--- a/test/core/always_attr.sv
+++ b/test/core/always_attr.sv
@@ -1,0 +1,10 @@
+module top;
+    reg a, b, c;
+    (* test *) always_ff @(posedge a)
+        c <= b;
+    (* test *) always_latch
+        if (c)
+            b <= 1;
+    (* test *) always_comb
+        a = b;
+endmodule

--- a/test/core/always_attr.v
+++ b/test/core/always_attr.v
@@ -1,0 +1,10 @@
+module top;
+    reg a, b, c;
+    (* test *) always @(posedge a)
+        c <= b;
+    (* test *) always @*
+        if (c)
+            b <= 1;
+    (* test *) always @*
+        a = b;
+endmodule


### PR DESCRIPTION
Everything is in the title.
Example triggering the bug
```
module top();
  wire a;
  (* test *) always_comb a = 1;
endmodule
```
There is a test folder in which this test might be worth adding, which subdirectory should I add it in?